### PR TITLE
Update autowind and autowait logic

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -685,9 +685,19 @@ bool CEdl::AddCut(Cut& cut)
     int autowind = g_advancedSettings.m_iEdlCommBreakAutowind * 1000; // seconds -> ms
 
     if (cut.start > 0) // Only autowait if not at the start.
-     cut.start += autowait;
-    if (cut.end > cut.start + autowind) // Only autowind if it won't go back past the start (should never happen).
-     cut.end -= autowind;
+    {
+      /* get the cut length so we don't start skipping after the end */
+      int cutLength = cut.end - cut.start;
+      /* add the lesser of the cut length or the autowait to the start */
+      cut.start += autowait > cutLength ? cutLength : autowait;
+    }
+    if (cut.end > cut.start) // Only autowind if there is any cut time remaining.
+    {
+      /* get the remaining cut length so we don't rewind to before the start */
+      int cutLength = cut.end - cut.start;
+      /* subtract the lesser of the cut length or the autowind from the end */
+      cut.end -= autowind > cutLength ? cutLength : autowind;
+    }
   }
 
   /*


### PR DESCRIPTION
Update the autowait and autowind logic to handle the extended times.
This change will in effect cause a cut to be skipped when the autowait + autowind values are greater than the length of the cut, but setting the start and end of the cut to the same time.
The code will not allow the end time for the cut to be less than the start time.

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
